### PR TITLE
Fix error in generateKey due to Base32 returning Buffers now

### DIFF
--- a/otp.js
+++ b/otp.js
@@ -44,7 +44,7 @@ function generateKey(length) {
   while(res.length < length) {
     res += set[Math.floor(Math.random() * set.length)];
   }
-  return Base32.encode(res).replace(/=/g, '');;
+  return Base32.encode(res).toString().replace(/=/g, '');
 }
 
 OTP.parse = function(str, options) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "url": "git://github.com/pipobscure/otp"
   },
   "dependencies": {
-    "thirty-two": "*"
+    "thirty-two": "^0.0.2"
   }
 }


### PR DESCRIPTION
Also restricted the dependency on `thirty-two` to make these errors less common.
