### PR TITLE
Fix unnecesary console.error

### DIFF
--- a/lib/otp.ts
+++ b/lib/otp.ts
@@ -73,7 +73,6 @@ function hotp(options: OTPOptions, counter: number): string {
   return `${new Array(options.codeLength).fill("0")}${code}`.slice(-1 * options.codeLength);
 }
 function totp(options: OTPOptions, now: number = Date.now()): string {
-  console.error(now, options);
   const counter = Math.floor((now - options.epoch * 1000) / (options.timeSlice * 1000));
   return hotp(options, counter);
 }


### PR DESCRIPTION
Every time we want to obtain the totp code, the function prints unnecessary messages on the console.