### PR TITLE
RangeError: offset is out of bounds in rekey()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log
 *.d.ts
 
 !rollup.config.js
+package-lock.json
+yarn.lock

--- a/lib/otp.ts
+++ b/lib/otp.ts
@@ -84,7 +84,6 @@ function hotp(options: OTPOptions, counter: number): string {
 	return `${new Array(options.codeLength).fill('0')}${code}`.slice(-1 * options.codeLength);
 }
 function totp(options: OTPOptions, now: number = Date.now()): string {
-	console.error(now, options);
 	const counter = Math.floor((now - options.epoch * 1000) / (options.timeSlice * 1000));
 	return hotp(options, counter);
 }

--- a/lib/otp.ts
+++ b/lib/otp.ts
@@ -99,8 +99,6 @@ function UInt64Buffer(num: number) {
 	return res;
 }
 
-const zeroBuffer = new Uint8Array(new Array(128).fill(0));
-
 class Hmac {
 	constructor(blocksize: number, key: Uint8Array) {
 		if (blocksize !== 128 && blocksize !== 64) {
@@ -140,7 +138,7 @@ function rekey(key: Uint8Array, blocksize: number): Uint8Array {
 	if (key.length < blocksize) {
 		const res = new Uint8Array(blocksize);
 		res.set(key);
-		res.set(zeroBuffer, key.length);
+		res.fill(0, key.length);
 		return res;
 	}
 	return key;


### PR DESCRIPTION
## Description

I encountered the error "RangeError: offset is out of bounds" invoking `totp()` when OTP is initialized with a **secret** shorter than blocksize is used. 

If I understood the code correctly, a short secret is padded with zeros, I extracted a few lines from the rekey routine:

```ts
      const zeroBuffer = new Uint8Array(new Array(128).fill(0));
      ...
      if (key.length < blocksize) {
          const res = new Uint8Array(blocksize);
          res.set(key);
          res.set(zeroBuffer, key.length);
          return res;
      }
```
`zeroBuffer` is always 128, which would break for a blocksize of 64. My approach is to fill the result with the zeros needed, but I am not sure if this would break any other scenario

```ts
      if (key.length < blocksize) {
          const res = new Uint8Array(blocksize);
          res.set(key);
          res.fill(0, key.length);
          return res;
      }
```

## Type of change

- [X] Bug fix