### PR TITLE
Fix `Hmac` block size to 64

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a utility to work with Google-Authenticator and compatible OTP-Mechanism
 Options can have the following properties:
 
 - **name**: A name used in generating URLs
-- **keySize**: The size of the OTP-Key (default 64) (possible values: 64 & 128)
+- **keySize**: The size of the OTP-Key in bytes (default 20). Used for generating a new secret
 - **codeLength**: The length of the code generated (default 6)
 - **secret**: The secret (either a Buffer of Base32-encoded String)
 - **epoch**: The seconds since Unix-Epoch to use as a base for calculating the TOTP (default 0)


### PR DESCRIPTION
Change the block size of `Hmac` class to 64 as it is HMAC-SHA1. The block size is 128 for HMAC-SHA512 which this implementation is not.

Also change the default `keySize` to 20 bytes (which is 32 characters of Base32). Key byte length was previously used for HMAC block size which is incorrect.